### PR TITLE
fixed challenge attribute in clientDataJSON

### DIFF
--- a/soft_webauthn.py
+++ b/soft_webauthn.py
@@ -63,7 +63,7 @@ class SoftWebauthnDevice():
         # generate credential response
         client_data = {
             'type': 'webauthn.create',
-            'challenge': urlsafe_b64encode(options['publicKey']['challenge']).decode('ascii'),
+            'challenge': urlsafe_b64encode(options['publicKey']['challenge']).decode('ascii').rstrip('='),
             'origin': origin
         }
 
@@ -101,7 +101,7 @@ class SoftWebauthnDevice():
         # prepare signature
         client_data = json.dumps({
             'type': 'webauthn.get',
-            'challenge': urlsafe_b64encode(options['publicKey']['challenge']).decode('ascii'),
+            'challenge': urlsafe_b64encode(options['publicKey']['challenge']).decode('ascii').rstrip('='),
             'origin': origin
         }).encode('utf-8')
         client_data_hash = sha256(client_data)


### PR DESCRIPTION
The webauthn specification for the challenge attribute in clientDataJSON doesn't contains the trailing = characters:

https://w3c.github.io/webauthn/#base64url-encoding

In the methods create and get methods of the class SoftWebauthnDevice you use base64.urlsafe_b64encode that does returns the value with the trailing = characters.

I noticed this programming the unit tests for a django app where I'm using py-webauthn. This = characters at the end of the challenge value makes the tests fails. I temporally fixed this in my app inheriting from SoftWebauthnDevice and overriding this methods to remove the = character from the challenge attribute.

This is the same description I added to the issue in your repo: [https://github.com/bodik/soft-webauthn/issues/8](https://github.com/bodik/soft-webauthn/issues/8)